### PR TITLE
New SSL requirement - Private keys need to be changed at every renewal

### DIFF
--- a/autossl/ssl.py
+++ b/autossl/ssl.py
@@ -228,7 +228,7 @@ class SslBlueprint(object):
 class SslCertificateConfig(object):
     def __init__(self, certificate_type, certificate_authority,
                  common_name=None, sans=None, organization=None, chain_of_trust=None,
-                 exact_match=False, private_key_reuse=True, private_key_size=4096,
+                 exact_match=False, private_key_reuse=False, private_key_size=4096,
                  renewal_delay=30, is_ca=False):
         """
 

--- a/tests/data/acme.example.com.yaml
+++ b/tests/data/acme.example.com.yaml
@@ -4,6 +4,7 @@ name: acme.example.com
 certificate:
   type: DV
   renewal_delay: 30
+  private_key_reuse: true
   certificate_authority: LetsEncrypt
   exact_match: true
   common_name: acme.example.com

--- a/tests/data/local.example.com.yaml
+++ b/tests/data/local.example.com.yaml
@@ -5,6 +5,7 @@ certificate:
   type: DV
   renewal_delay: 30
   certificate_authority: Autossl
+  private_key_reuse: true
   exact_match: true
   common_name: local.example.com
   san:

--- a/tests/data/local_no_chain_of_trust.example.com.yaml
+++ b/tests/data/local_no_chain_of_trust.example.com.yaml
@@ -4,6 +4,7 @@ name: local.example.com
 certificate:
   type: OV
   renewal_delay: 30
+  private_key_reuse: true
   certificate_authority: Sectigo
   exact_match: true
   common_name: local.example.com

--- a/tests/data/localca.example.com.yaml
+++ b/tests/data/localca.example.com.yaml
@@ -5,6 +5,7 @@ certificate:
   type: DV
   renewal_delay: 30
   certificate_authority: autossl
+  private_key_reuse: true
   exact_match: true
   common_name: localca.example.com
   san:

--- a/tests/data/subca.example.com.yaml
+++ b/tests/data/subca.example.com.yaml
@@ -5,6 +5,7 @@ certificate:
   type: DV
   renewal_delay: 30
   certificate_authority: Autossl
+  private_key_reuse: true
   exact_match: true
   common_name: subca.example.com
   is_ca: true

--- a/tests/data/tst.dv.example.com.yaml
+++ b/tests/data/tst.dv.example.com.yaml
@@ -6,6 +6,7 @@ certificate:
   renewal_delay: 30
   certificate_authority: LetsEncrypt
   exact_match: true
+  private_key_reuse: true
   common_name: tst.autossl.example.com
   san:
     - tst.autossl.example.com

--- a/tests/data/tst.ov.example.com_minimal.yaml
+++ b/tests/data/tst.ov.example.com_minimal.yaml
@@ -6,6 +6,7 @@ certificate:
   renewal_delay: 30
   certificate_authority: LetsEncrypt
   exact_match: true
+  private_key_reuse: true
   common_name: tst.autossl.example.com
   san:
     - tst.autossl.example.com

--- a/tests/data/tst.ov.example.com_no-server.yaml
+++ b/tests/data/tst.ov.example.com_no-server.yaml
@@ -4,6 +4,7 @@ name: auto_tst.autossl.example.com
 certificate:
   type: OV
   renewal_delay: 30
+  private_key_reuse: true
   certificate_authority: Sectigo
   common_name: tst.autossl.example.com
   san:


### PR DESCRIPTION
The Certificate Team in Amadeus now requires a new private key to be generated for security purposes.

It makes sense to renew certificates with a new private key by default as it helps rotating them more frequently. 
Generating a new CSR with an already existing private key is a security vulnerability.
