### PR TITLE
Reduce default key size to 2048 from 4096

### DIFF
--- a/autossl/__version__.py
+++ b/autossl/__version__.py
@@ -1,7 +1,7 @@
 __title__ = 'autossl'
 __description__ = 'SSL certificates monitoring, renewal and deployment.'
 __url__ = 'https://autossl.readthedocs.io'
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 __author__ = 'Thibaud Castaing'
 __author_email__ = 't-cas@users.noreply.github.com'
 __license__ = 'MIT license'

--- a/autossl/ssl.py
+++ b/autossl/ssl.py
@@ -228,7 +228,7 @@ class SslBlueprint(object):
 class SslCertificateConfig(object):
     def __init__(self, certificate_type, certificate_authority,
                  common_name=None, sans=None, organization=None, chain_of_trust=None,
-                 exact_match=False, private_key_reuse=False, private_key_size=4096,
+                 exact_match=False, private_key_reuse=False, private_key_size=2048,
                  renewal_delay=30, is_ca=False):
         """
 
@@ -383,7 +383,7 @@ def generate_csr(name,
                  email_address=None,
                  sans=None,
                  key_content=None,
-                 key_size=4096,
+                 key_size=2048,
                  output_path=None,
                  is_ca=False):
     """Generate a CSR for specified parameters


### PR DESCRIPTION
Related to Imperva key size limitation documented [here](https://docs.imperva.com/bundle/cloud-application-security/page/release-notes/2021-08-15.htm#RSAkeylengthlimitforcustomcertificates)